### PR TITLE
Create a wallet before calling getnewaddress

### DIFF
--- a/lib/mining-utils.js
+++ b/lib/mining-utils.js
@@ -107,6 +107,10 @@ function bitcoindPromiseRequest(method, params, poolContext) {
 }
 
 async function bitcoinGenerateBlocks(numberOfBlocks) {
+  const walletResponse = await bitcoindPromiseRequest("createwallet", ["testwallet"], defaultBTCContext);
+  const walletWarning = JSON.parse(walletResponse).result.warning;
+  if (walletWarning !== "")
+    console.log(walletWarning);
   const addressResponse = await bitcoindPromiseRequest("getnewaddress", [], defaultBTCContext);
   const address = JSON.parse(addressResponse).result;
   const generateResponse = await bitcoindPromiseRequest("generatetoaddress", [numberOfBlocks, address], defaultBTCContext);


### PR DESCRIPTION
Since Bitcoin Core 0.21.0, no wallet is created by default.