### PR TITLE
Storing logs and test metadata for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,3 +71,6 @@ jobs:
       
       - store_artifacts:
           path: ~/tmp/Results/mocha
+          
+      - store_artifacts:
+          path: ~/tmp/logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -988,13 +988,13 @@
       }
     },
     "md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
       "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "md5.js": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "RSK mining integration tests",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --reporter mocha-junit-reporter --reporter-options mochaFile=./Results/mocha/Test-Results.xml"
   },
   "author": "RSK",
   "license": "MIT",


### PR DESCRIPTION
Updated config.yml and dependencies to allow the storage of rsk.log and test metadata for CircleCI.
Test related info will be available on Test tab of each job run with this configuration.