### PR TITLE
Change node version to 12 in circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/node:12.22-browsers
+      - image: cimg/openjdk:8.0.242-node
       - image: kylemanna/bitcoind:latest
         name: bitcoind01
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/openjdk:8.0-node
-
+      - image: cimg/node:12.19-browsers
       - image: kylemanna/bitcoind:latest
         name: bitcoind01
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/node:12.19-browsers
+      - image: cimg/node:12.22-browsers
       - image: kylemanna/bitcoind:latest
         name: bitcoind01
         environment:


### PR DESCRIPTION
Previous image was pointing to node 20.9 of which the current library dependencies not work, the circle CI image was change to use node 12 for execution.